### PR TITLE
feat: github collectStarsWorker and tests

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,10 @@ export const secretAccessKey = getConfigs().secretAccessKey;
 export const githubAPIToken = getConfigs().githubAPIToken;
 export const cocoEndPoint = getConfigs().cocoEndPoint;
 export const cocoAuthKey = getConfigs().cocoAuthKey;
+// GitHub API rate limit is 5000 for authenticated users. Be conservative and set this to 2000.
+export const githubHourlyRateLimit = getConfigs().githubHourlyRateLimit;
+// the repository where public ops related issues can be created. Eg. "phcode-dev/extensionService"
+export const opsRepo = getConfigs().opsRepo;
 export const DATABASE_NAME = `phcode_extensions_${stage}`;
 export const EXTENSIONS_DETAILS_TABLE = `${DATABASE_NAME}.extensionDetails`;
 export const RELEASE_DETAILS_TABLE = `${DATABASE_NAME}.releaseDetails`;

--- a/src/server.js
+++ b/src/server.js
@@ -29,9 +29,10 @@ import {getHelloSchema, hello} from "./api/hello.js";
 import {getPublishGithubReleaseSchema, publishGithubRelease} from "./api/publishGithubRelease.js";
 import path from 'path';
 import { fileURLToPath } from 'url';
-import {initGitHubClient} from "./github.js";
+import {initGitHubClient, setupGitHubOpsMonitoring} from "./github.js";
 import {getGetGithubReleaseStatusSchema, getGithubReleaseStatus} from "./api/getGithubReleaseStatus.js";
 import {getCountDownloadSchema, countDownload} from "./api/countDownload.js";
+import {startCollectStarsWorker} from "./utils/sync.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -124,6 +125,8 @@ export async function startServer() {
     console.log("awaiting connection to coco db");
     await db.init(cocoEndPoint, cocoAuthKey);
     initGitHubClient();
+    setupGitHubOpsMonitoring();
+    startCollectStarsWorker();
     console.log("connected to coco db");
     setupTasks();
     const configs = getConfigs();

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -3,7 +3,8 @@ import * as fs from "fs";
 let APP_CONFIG = null;
 
 function _checkRequiredConfigs(config) {
-    const requiredConfigVars = ["cocoEndPoint", "cocoAuthKey", "stage", "githubAPIToken", "baseURL"];
+    const requiredConfigVars = ["cocoEndPoint", "cocoAuthKey", "stage", "githubAPIToken", "baseURL",
+        "githubHourlyRateLimit", "opsRepo"];
     let missingEnvVars = [];
     for (let envName of requiredConfigVars){
         if(!config[envName]){

--- a/src/utils/sync.js
+++ b/src/utils/sync.js
@@ -3,10 +3,12 @@ import {
     EXTENSIONS_DETAILS_TABLE,
     POPULARITY_FILE,
     REGISTRY_FILE,
-    REGISTRY_VERSION_FILE
+    REGISTRY_VERSION_FILE,
+    FIELD_EXTENSION_ID
 } from "../constants.js";
 import db from "../db.js";
 import {S3} from "../s3.js";
+import {getRepoDetails} from "../github.js";
 
 export async function syncRegistryDBToS3JSON() {
     console.log("syncing non synced extension data in db to s3 extension.json");
@@ -57,4 +59,93 @@ export async function syncRegistryDBToS3JSON() {
             `$.metadata.version='${document.metadata.version}'`));
     }
     console.log("syncPending status updated in db for: ", await Promise.all(updatePromises));
+}
+
+
+const ONE_HOUR = 1000*60*60, HOURS_IN_DAY = 24, ONE_DAY = ONE_HOUR * HOURS_IN_DAY;
+let extensionsStarsCollectedToday = []; // will be reset every day, collect stars from GitHub once daily
+
+async function _updateStargazerCount(owner, repo, extensionId) {
+    let repoDetails = await getRepoDetails(owner, repo, false);
+    if(repoDetails) {
+        const queryObj = {};
+        queryObj[FIELD_EXTENSION_ID] = extensionId;
+        let registryPKGJSON = await db.getFromIndex(EXTENSIONS_DETAILS_TABLE, queryObj);
+        if(!registryPKGJSON.isSuccess){
+            console.error("Error getting extensionPKG details from db: " + extensionId);
+            // dont fail, continue with next repo
+            return;
+        }
+        if(registryPKGJSON.documents.length === 1){
+            const document = registryPKGJSON.documents[0];
+            const documentId = registryPKGJSON.documents[0].documentId;
+            document.gihubStars = repoDetails.stargazers_count;
+            let status = await db.update(EXTENSIONS_DETAILS_TABLE, documentId, document,
+                `$.metadata.version='${document.metadata.version}'`);
+            if(!status.isSuccess) {
+                console.error("Error updating stars for extension in db: " + extensionId);
+                // dont fail, continue with next repo
+                return;
+            }
+        }
+    }
+}
+
+/**
+ * Collects github star count every hour in batches considering GitHub throttles at 2000 GitHub Api requests per hour.
+ */
+export async function _collectStarsWorker() { // exported for tests only
+    console.log("Number of extensions whose stars collected today: ", extensionsStarsCollectedToday.length);
+    let registry = JSON.parse(await S3.getObject(EXTENSIONS_BUCKET, REGISTRY_FILE));
+    let extensionIDs = Object.keys(registry);
+    const numExtensionsToCollect = (extensionIDs.length/HOURS_IN_DAY) * 2; // so that the task completes in half day
+    let extensionsToCollect = []; // all extensions whose stars have not been collected today
+    for(let extensionID of extensionIDs) {
+        if(extensionsStarsCollectedToday.includes(extensionID)){
+            // already collected
+            continue;
+        }
+        if(!registry[extensionID].ownerRepo){
+            // no repo, so nothing to see here
+            extensionsStarsCollectedToday.push(extensionID);
+            continue;
+        }
+        extensionsToCollect.push(extensionID);
+    }
+    let collectedStarsForExtensions = [];
+    for(let i=0; i < numExtensionsToCollect && i < extensionsToCollect.length; i++){
+        let extensionID = extensionsToCollect[i];
+        let repoSplit = registry[extensionID].ownerRepo.split("/");//"https://github.com/Brackets-Themes/808"
+        const repo = repoSplit[repoSplit.length-1],
+            owner = repoSplit[repoSplit.length-2];
+        // this is purposefully serial
+        await _updateStargazerCount(owner, repo, extensionID);
+        extensionsStarsCollectedToday.push(extensionID);
+        collectedStarsForExtensions.push(extensionID);
+    }
+    console.log(`collecting stars for ${collectedStarsForExtensions.length} extensions of MAX allowed ${numExtensionsToCollect}`);
+    return {collectedStarsForExtensions, extensionsStarsCollectedToday};
+}
+
+/* c8 ignore start */
+// not testing this as no time and is manually tested. If you are touching this code, manual test thoroughly
+let worker;
+export function startCollectStarsWorker() {
+    if(worker){
+        return;
+    }
+    worker = setInterval(_collectStarsWorker, ONE_HOUR);
+    setInterval(()=>{
+        extensionsStarsCollectedToday = [];
+    }, ONE_DAY);
+}
+/* c8 ignore end */
+/**
+ * sets download count of extensions.
+ * publishes registry.json and popularity.json into s3
+ * does not increase registry_version.json
+ * @private
+ */
+function _syncPopularityHourly() {
+
 }

--- a/test/integration/hello.spec.js
+++ b/test/integration/hello.spec.js
@@ -47,11 +47,11 @@ describe('Integration Tests for hello api', function () {
         let output = await fetch("http://localhost:5000/www", { method: 'GET'});
         expect(output.status).eql(200);
         output = await output.text();
-        expect(output.includes("Hello HTML")).eql(true);
+        expect(output.includes("<!DOCTYPE html>")).eql(true);
         output = await fetch("http://localhost:5000/www/", { method: 'GET'});
         expect(output.status).eql(200);
         output = await output.text();
-        expect(output.includes("Hello HTML")).eql(true);
+        expect(output.includes("<!DOCTYPE html>")).eql(true);
     });
 
     it('should get 404 if static web page doesnt exist', async function () {

--- a/test/integration/setupTestConfig.js
+++ b/test/integration/setupTestConfig.js
@@ -12,7 +12,9 @@ const defaultTestConfig = {
     "accessKeyId": "update in testConfig.json file to run integ tests",
     "secretAccessKey": "update in testConfig.json file to run integ tests",
     "githubAPIToken": "update in testConfig.json file to run integ tests",
-    "baseURL": "update in testConfig.json file to run integ tests"
+    "baseURL": "update in testConfig.json file to run integ tests",
+    "githubHourlyRateLimit": "update in testConfig.json file to run integ tests",
+    "opsRepo": "update in testConfig.json file to run integ tests"
 };
 
 

--- a/test/unit/setupMocks.js
+++ b/test/unit/setupMocks.js
@@ -135,11 +135,11 @@ export function setS3Mock(bucket, key, contents) {
  * @param org
  * @param repo
  */
-export function getRepoDetails(org, repo) {
+export function getRepoDetails(org, repo, starGazers = 3) {
     mockedFunctions.githubRequestFnMock = githubRequestFnMock;
     getRepoDetailsResponses[`${org}/${repo}`] = {
         data: {
-            stargazers_count: 3,
+            stargazers_count: starGazers,
             html_url: `https://github.com/${org}/${repo}`
         }
     };

--- a/test/unit/utils/.app.json
+++ b/test/unit/utils/.app.json
@@ -7,6 +7,8 @@
   "stage": "test",
   "githubAPIToken": "githubToken",
   "baseURL": "http://localhost:5000",
+  "githubHourlyRateLimit": 2000,
+  "opsRepo": "phcode-dev/extensionService",
   "mysql": {
     "host": "localhost",
     "port": "3306",

--- a/test/unit/utils/sync-test.spec.js
+++ b/test/unit/utils/sync-test.spec.js
@@ -1,0 +1,103 @@
+/*global describe, it, before, beforeEach, after*/
+import mockedFunctions, {setS3Mock} from "../setupMocks.js";
+import * as chai from 'chai';
+import {initGitHubClient} from "../../../src/github.js";
+import {S3} from "../../../src/s3.js";
+import db from "../../../src/db.js";
+import {_collectStarsWorker} from "../../../src/utils/sync.js";
+import {default as registry} from "../data/registry.js";
+import {
+    EXTENSIONS_BUCKET,
+    EXTENSIONS_DETAILS_TABLE,
+    FIELD_EXTENSION_ID,
+    REGISTRY_FILE
+} from "../../../src/constants.js";
+
+let expect = chai.expect;
+
+describe('unit Tests for sync', function () {
+    let _getObject, options, githubResponse;
+
+    before(function () {
+        initGitHubClient();
+        mockedFunctions.githubMock.reset();
+        mockedFunctions.githubMock.getRepoDetails("org", "repo");
+        _getObject = S3.getObject;
+    });
+
+    after(()=>{
+        S3.getObject = _getObject;
+    });
+
+    let documents = {}, docID = 0;
+    beforeEach(function () {
+        documents = {};
+        db.put = function (tableName, document) {
+            let newDocID = "" + docID++;
+            documents[tableName + ":" + newDocID] = document;
+            return {isSuccess: true, documentId: newDocID};
+        };
+        setS3Mock(EXTENSIONS_BUCKET, REGISTRY_FILE, JSON.stringify(registry));
+        mockedFunctions.githubMock.reset();
+        for(let key of Object.keys(registry)){
+            let registryEntry = registry[key];
+            registryEntry[FIELD_EXTENSION_ID] = key;
+            db.put(EXTENSIONS_DETAILS_TABLE, registryEntry);
+            if(registryEntry.ownerRepo) {
+                let repoSplit = registryEntry.ownerRepo.split("/");//"https://github.com/Brackets-Themes/808"
+                const repo = repoSplit[repoSplit.length-1],
+                    owner = repoSplit[repoSplit.length-2];
+                mockedFunctions.githubMock.getRepoDetails(owner, repo, 2345);
+            }
+        }
+        db.getFromIndex = function (tableName, queryObject) {
+            let keys = Object.keys(documents);
+            let foundDocs =[];
+            for(let key of keys){
+                if(key.startsWith(tableName+":")){
+                    let doc = documents[key];
+                    let qKeys = Object.keys(queryObject);
+                    for (let qkey of qKeys){
+                        if(doc[qkey] === queryObject[qkey]){
+                            foundDocs.push(doc);
+                        }
+                    }
+                }
+            }
+            return {isSuccess: true,
+                documents:foundDocs
+            };
+        };
+        db.update = function () {
+            return {isSuccess: true,
+                documents:[]
+            };
+        };
+    });
+
+    it('_collectStarsWorker collect stars', async function () {
+        let {collectedStarsForExtensions, extensionsStarsCollectedToday} = await _collectStarsWorker();
+        extensionsStarsCollectedToday = structuredClone(extensionsStarsCollectedToday);
+        expect(extensionsStarsCollectedToday.length).to.gte(collectedStarsForExtensions.length);
+        const queryObj = {};
+        queryObj[FIELD_EXTENSION_ID] = collectedStarsForExtensions[0];
+        let status = await db.getFromIndex(EXTENSIONS_DETAILS_TABLE, queryObj);
+        expect(status.isSuccess).to.be.true;
+        expect(status.documents[0].gihubStars).eq(2345);
+        // run again
+        let newRun = await _collectStarsWorker();
+        expect(newRun.extensionsStarsCollectedToday.length).to.gt(extensionsStarsCollectedToday.length);
+        expect(newRun.collectedStarsForExtensions.length).to.eq(collectedStarsForExtensions.length);
+        for(let extension of newRun.collectedStarsForExtensions){
+            expect(collectedStarsForExtensions.includes(extension)).to.be.false;
+        }
+        // now run it a few times so that all extension stars collected
+        while(newRun.collectedStarsForExtensions.length){
+            newRun = await _collectStarsWorker();
+        }
+        newRun = await _collectStarsWorker();
+        expect(newRun.extensionsStarsCollectedToday.length).to.eq(Object.keys(registry).length);
+        expect(newRun.collectedStarsForExtensions.length).to.eq(0);
+    });
+
+});


### PR DESCRIPTION
The worker runs every hour, collects stars of `totalExtensions/24*2` repositories (About 112 extensions per hour for 1333 extensions). We must do this as GitHub API has rate limits of around 2000/hr(5000/hr for our phcode-ide bot, but we conservatively set to 2000). 

A gihub issue will be raised on this repo if more than half of the hourly github quota is used. The same issue will be used for a period of 24 hours for updates. Eg. https://github.com/phcode-dev/extensionService/issues/23